### PR TITLE
Elliptic cylinder.

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -1806,6 +1806,83 @@ for solid CAD anyway.
         result.properties.roundedCylinder.facepoint = p1.plus(xvector);
         return result;
     };
+	
+	// Construct a elliptic cylinder.
+    //
+    // Parameters:
+    //   start: start point of cylinder (default [0, -1, 0])
+    //   end: end point of cylinder (default [0, 1, 0])
+    //   radius: radius of cylinder (default [1,1]), must be two dimensional array
+	//	 radiusStart: can be used instead of radius with combination with radiousEnd
+	//	 radiusEnd: can be used instead of radius with combination with radiusStart
+    //   resolution: determines the number of polygons per 360 degree revolution (default 12)
+    //
+    // Example usage:
+    //
+    //     var cylinder = CSG.cylinderElliptic({
+    //       start: [0, -1, 0],
+    //       end: [0, 1, 0],
+    //       radiusStart: [10, 5],
+	//       radiusStart: [8, 3],
+    //       resolution: 16
+    //     });
+	CSG.cylinderElliptic = function(options) {
+		var s = CSG.parseOptionAs3DVector(options, "start", [0, -1, 0]);
+		var e = CSG.parseOptionAs3DVector(options, "end", [0, 1, 0]);
+		var r = CSG.parseOptionAs2DVector(options, "radius", [1,1]);
+		var rEnd = CSG.parseOptionAs2DVector(options, "radiusEnd", r);
+		var rStart = CSG.parseOptionAs2DVector(options, "radiusStart", r);
+
+		if((rEnd._x < 0) || (rStart._x < 0) || (rEnd._y < 0) || (rStart._y < 0) ) {
+			throw new Error("Radius should be non-negative");
+		}
+		if((rEnd._x === 0 || rEnd._y === 0) && (rStart._x === 0 || rStart._y === 0)) {
+			throw new Error("Either radiusStart or radiusEnd should be positive");
+		}
+
+		var slices = CSG.parseOptionAsInt(options, "resolution", CSG.defaultResolution2D);
+		var ray = e.minus(s);
+		var axisZ = ray.unit(); //, isY = (Math.abs(axisZ.y) > 0.5);
+		var axisX = axisZ.randomNonParallelVector().unit();
+
+		//  var axisX = new CSG.Vector3D(isY, !isY, 0).cross(axisZ).unit();
+		var axisY = axisX.cross(axisZ).unit();
+		var start = new CSG.Vertex(s);
+		var end = new CSG.Vertex(e);
+		var polygons = [];
+
+		function point(stack, slice, radius) {
+			var angle = slice * Math.PI * 2;
+			var out = axisX.times(radius._x * Math.cos(angle)).plus(axisY.times(radius._y * Math.sin(angle)));
+			var pos = s.plus(ray.times(stack)).plus(out);
+			return new CSG.Vertex(pos);
+		}
+		for(var i = 0; i < slices; i++) {
+			var t0 = i / slices,
+				t1 = (i + 1) / slices;
+			
+			if(rEnd._x == rStart._x && rEnd._y == rStart._y) {
+				polygons.push(new CSG.Polygon([start, point(0, t0, rEnd), point(0, t1, rEnd)]));
+				polygons.push(new CSG.Polygon([point(0, t1, rEnd), point(0, t0, rEnd), point(1, t0, rEnd), point(1, t1, rEnd)]));
+				polygons.push(new CSG.Polygon([end, point(1, t1, rEnd), point(1, t0, rEnd)]));
+			} else {
+				if(rStart._x > 0) {
+					polygons.push(new CSG.Polygon([start, point(0, t0, rStart), point(0, t1, rStart)]));
+					polygons.push(new CSG.Polygon([point(0, t0, rStart), point(1, t0, rEnd), point(0, t1, rStart)]));
+				}
+				if(rEnd._x > 0) {
+					polygons.push(new CSG.Polygon([end, point(1, t1, rEnd), point(1, t0, rEnd)]));
+					polygons.push(new CSG.Polygon([point(1, t0, rEnd), point(1, t1, rEnd), point(0, t1, rStart)]));
+				}
+			}
+		}
+		var result = CSG.fromPolygons(polygons);
+		result.properties.cylinder = new CSG.Properties();
+		result.properties.cylinder.start = new CSG.Connector(s, axisZ.negated(), axisX);
+		result.properties.cylinder.end = new CSG.Connector(e, axisZ, axisX);
+		result.properties.cylinder.facepoint = s.plus(axisX.times(rStart));
+		return result;
+	};
 
     // Construct an axis-aligned solid rounded cuboid.
     // Parameters:


### PR DESCRIPTION
As requested in https://github.com/joostn/OpenJsCad/pull/89, @kaosat-dev, @z3dev :)

Here's how it goes:

check the [PR you want to backport](https://github.com/Spiritdude/OpenJSCAD.org/pull/94/commits) and find out the commits you need, here:

    f5a339de9278

Clone the commiters repo (the commit is obviously there), and then run [format-patch](https://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html):

    git format-patch -1 f5a339d
    # 0001-Elliptic-cylinder.patch

Open your own csg.js fork, checkout a new branch from master and :

    # Check you can safely apply the patch
    git apply --check 0001-Elliptic-cylinder.patch

If you got an error, you'll need to fiddle with the patch by editing it. I attach the original patch and edited [here: Archive.zip](https://github.com/jscad/csg.js/files/737916/Archive.zip).
I basically removed the "-" lines that removes something that is not in the original file, then changes the line number to match the new csg structure.

    git apply --check 0002-Elliptic-cylinder.patch
    # No errors !
    git checkout -b elliptic_cylinder
    # --signoff option to register who did the patch adaptation job ;)
    git am --signoff < 0002-Elliptic-cylinder.patch
    git push origin elliptic_cylinder

There's maybe a better way for doing this, but that's the best I know.