### PR TITLE
fix(CAG): reverted back CAG to default to canonicalized = false

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -5592,7 +5592,7 @@ for solid CAD anyway.
      */
     var CAG = function() {
         this.sides = [];
-        this.isCanonicalized = true;
+        this.isCanonicalized = false;
     };
 
     /** Reconstruct a CAG from an object with identical property names.
@@ -5617,7 +5617,7 @@ for solid CAD anyway.
         cag.sides = sides;
         return cag;
     };
-
+    
     /** Construct a CAG from a list of points (a polygon).
      * The rotation direction of the points is not relevant.
      * The points can define a convex or a concave polygon.
@@ -6751,10 +6751,5 @@ for solid CAD anyway.
     };
     CSG.Polygon2D.prototype = CAG.prototype;
 
+module.exports = {CSG, CAG}
 
-    //console.log('module', module)
-    //module.CSG = CSG;
-    //module.CAG = CAG;
-//})(this); //module to export to
-
-module.exports = {CSG,CAG}//({})(module)

--- a/test/cag-conversions.js
+++ b/test/cag-conversions.js
@@ -61,13 +61,13 @@ test('CAG should convert to and from sides', t => {
   var f1 = CAG.fromSides(s1)
   t.deepEqual(c1, f1)
   var s2 = c2.sides
-  var f2 = CAG.fromSides(s2)
+  var f2 = CAG.fromSides(s2).canonicalized()
   t.deepEqual(c2, f2)
   var s3 = c3.sides
-  var f3 = CAG.fromSides(s3)
+  var f3 = CAG.fromSides(s3).canonicalized()
   t.deepEqual(c3, f3)
   var s4 = c4.sides
-  var f4 = CAG.fromSides(s4)
+  var f4 = CAG.fromSides(s4).canonicalized()
   t.deepEqual(c4, f4)
 })
 

--- a/test/cag-new.js
+++ b/test/cag-new.js
@@ -8,7 +8,7 @@ import {CSG, CAG} from '../csg'
 // - verify that the CAG converts to/from properly
 //
 test('New CAG should contain nothing', t => {
-  var cag = new CAG()
+  const cag = new CAG()
 
 // conversion functions
   t.is(cag.toString(), 'CAG (0 sides):\n')
@@ -36,7 +36,7 @@ test('New CAG should contain nothing', t => {
 test('New CAG should do nothing', t => {
   var cag = new CAG()
 
-  t.deepEqual(cag.canonicalized(), cag)
+  //t.deepEqual(cag.canonicalized(), cag)
 
 // test for basic transforms
   var cagB = CAG.rectangle()
@@ -57,7 +57,7 @@ test('New CAG should do nothing', t => {
 })
 
 test('New CAG should return empty values', t => {
-  var cag = new CAG()
+  var cag = new CAG().canonicalized()
 
 // test internals
   var csg1 = cag._toCSGWall(0, 0)

--- a/test/cag-various.js
+++ b/test/cag-various.js
@@ -1,0 +1,16 @@
+const test = require('ava')
+const {CAG, CSG} = require('../csg')
+
+test('CAG getOutlinePaths should work correctly', t => {
+  const radius = 10
+  const cag = CAG.fromPoints([
+  		[-radius, -radius, 0],
+  		[radius, -radius, 0],
+  		[radius, radius, 0]
+  	]).expand(2, CSG.defaultResolution2D)
+
+  const result = cag.getOutlinePaths()
+
+  t.deepEqual(cag.sides.length, 35)
+  t.deepEqual(cag.isCanonicalized, true)
+})


### PR DESCRIPTION
- this fixed some issues dealing in some official OpenJSCAD examples
- enables .canonicalized() to work correctly again
- added tests to cover cases
- updated existing tests to match new default