### PR TITLE
refactor(csg.js): move Path2.innerToCAG to CAGFactories. Renamed as f…

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -163,6 +163,7 @@ CSG.toPointCloud = require('./src/debugHelpers').toPointCloud
 const CAGMakers = require('./src/CAGFactories')
 CAG.fromObject = CAGMakers.fromObject
 CAG.fromPointsNoCheck = CAGMakers.fromPointsNoCheck
+CAG.fromPath2 = CAGMakers.fromPath2
 
 // ////////////////////////////////////
 addTransformationMethodsToPrototype(CSG.prototype)

--- a/src/CAGFactories.js
+++ b/src/CAGFactories.js
@@ -2,6 +2,7 @@ const CAG = require('./CAG')
 const Side = require('./math/Side')
 const Vector2D = require('./math/Vector2')
 const Vertex = require('./math/Vertex2')
+const Path2 = require('./math/Path2')
 
 /** Reconstruct a CAG from an object with identical property names.
  * @param {Object} obj - anonymous object, typically from JSON
@@ -38,8 +39,20 @@ const fromPointsNoCheck = function (points) {
   return CAG.fromSides(sides)
 }
 
+/** Construct a CAG from a 2d-path (a closed sequence of points).
+ * Like fromPoints() but does not check if the result is a valid polygon.
+ * @param {path} Path2 - a Path2 path
+ * @returns {CAG} new CAG object
+ */
+const fromPath2 = function (path) {
+  if (!path.isClosed()) throw new Error('The path should be closed!')
+  return CAG.fromPoints(path.getPoints())
+}
+
+
 module.exports = {
   fromObject,
   fromPointsNoCheck,
+  fromPath2
   //fromFakeCSG
 }

--- a/src/math/Path2.js
+++ b/src/math/Path2.js
@@ -95,6 +95,15 @@ Path2D.prototype = {
     return new Path2D(newpoints)
   },
 
+  /**
+   * get the array of Vector2 points that make up the path
+   * note that this is current internal list of points, not an immutable copy.
+   * @returns {Vector2[]} array of points the make up the path
+   */
+  getPoints: function() {
+    return this.points;
+  },
+
   appendPoint: function (point) {
     if (this.closed) {
       throw new Error('Path must not be closed')
@@ -117,6 +126,14 @@ Path2D.prototype = {
 
   close: function () {
     return new Path2D(this.points, true)
+  },
+
+  /**
+   * Tell whether the path is a closed path or not
+   * @returns {boolean} true when the path is closed. false otherwise.
+   */
+  isClosed: function() {
+    return this.closed
   },
 
     // Extrude the path by following it with a rectangle (upright, perpendicular to the path direction)
@@ -155,12 +172,6 @@ Path2D.prototype = {
     let shellcag = CAG.fromSides(sides)
     let expanded = shellcag.expandedShell(pathradius, resolution)
     return expanded
-  },
-
-  innerToCAG: function () {
-    const CAG = require('../CAG') // FIXME: cyclic dependencies CAG => PATH2 => CAG
-    if (!this.closed) throw new Error('The path should be closed!')
-    return CAG.fromPoints(this.points)
   },
 
   transform: function (matrix4x4) {

--- a/src/primitives2d.js
+++ b/src/primitives2d.js
@@ -58,7 +58,7 @@ const ellipse = function (options) {
     large: false
   })
   e2 = e2.close()
-  return e2.innerToCAG()
+  return CAG.fromPath2(e2)
 }
 
 /** Construct a rectangle.

--- a/test/cag-conversions.js
+++ b/test/cag-conversions.js
@@ -113,19 +113,19 @@ test('CAG should convert to and from paths', t => {
   // convert to array of CSG.Path2D
   var s1 = c1.getOutlinePaths()
   var p1 = s1[0] // use first path from list of paths
-  var f1 = p1.innerToCAG()
+  var f1 = CAG.fromPath2(p1)
   t.deepEqual(c1.toPoints(), f1.toPoints())
   var s2 = c2.getOutlinePaths()
   var p2 = s2[0] // use first path from list of paths
-  var f2 = p2.innerToCAG()
+  var f2 = CAG.fromPath2(p2)
   t.deepEqual(c2.toPoints(), f2.toPoints())
   var s3 = c3.getOutlinePaths()
   var p3 = s3[0] // use first path from list of paths
-  var f3 = p3.innerToCAG()
+  var f3 = CAG.fromPath2(p3)
   t.deepEqual(c3.toPoints(), f3.toPoints())
   var s4 = c4.getOutlinePaths()
   var p4 = s4[0] // use first path from list of paths
-  var f4 = p4.innerToCAG()
+  var f4 = CAG.fromPath2(p4)
   // Order of points is wrong, see Issue #35
   // t.deepEqual(c4.toPoints(), f4.toPoints())
 })


### PR DESCRIPTION
This a pull request regarding innerToCAG => fromPath2