### PR TITLE
Fix shared object without color

### DIFF
--- a/src/math/Polygon3.js
+++ b/src/math/Polygon3.js
@@ -513,7 +513,7 @@ Polygon.isStrictlyConvexPoint = function (prevpoint, point, nextpoint, normal) {
  *   let shared = new CSG.Polygon.Shared([0, 0, 0, 1])
  */
 Polygon.Shared = function (color) {
-  if (color != null) {
+  if (color !== null && color !== undefined) {
     if (color.length !== 4) {
       throw new Error('Expecting 4 element array')
     }

--- a/src/math/Polygon3.js
+++ b/src/math/Polygon3.js
@@ -513,7 +513,7 @@ Polygon.isStrictlyConvexPoint = function (prevpoint, point, nextpoint, normal) {
  *   let shared = new CSG.Polygon.Shared([0, 0, 0, 1])
  */
 Polygon.Shared = function (color) {
-  if (color !== null) {
+  if (color != null) {
     if (color.length !== 4) {
       throw new Error('Expecting 4 element array')
     }

--- a/test/polygon3.js
+++ b/test/polygon3.js
@@ -231,15 +231,21 @@ test('CSG.Polygon.Shared construction', t => {
 
   t.deepEqual(s4.color,[6,7,8,9])
 
-  let s6 = CSG.Polygon.Shared.fromColor([4,3,2])
-
-  t.deepEqual(s6.color,[4,3,2,1])
-
 // check that generic objects are possible via JSON
   let o5 = JSON.parse(JSON.stringify(s4))
   let s5 = CSG.Polygon.Shared.fromObject(o5)
 
   t.deepEqual(o5,JSON.parse(JSON.stringify(s5)))
+
+  let s6 = CSG.Polygon.Shared.fromColor([4,3,2])
+
+  t.deepEqual(s6.color,[4,3,2,1])
+
+// check that fromObject works without a color
+  let o7 = new CSG.Polygon.Shared()
+  let s7 = CSG.Polygon.Shared.fromObject(o7)
+
+  t.deepEqual(o7, s7)
 
 // check member functions
   let h1 = s1.getHash()


### PR DESCRIPTION
One has to call the constructor `CSG.Polygon.Shared` either with a color or `null`. This means that you can't do `CSG.Polygon.Shared.fromObject(new CSG.Polygon.Shared(null))`.

This PR fixes that. So now you can do `new CSG.Polygon.Shared()` as well as `CSG.Polygon.Shared.fromObject(new CSG.Polygon.Shared())`.