### PR TITLE
fix(CAG): added back missing CAG.fromCompactBinary

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -162,13 +162,14 @@ CSG.fromPolygons = fromPolygons
 
 CSG.toPointCloud = require('./src/api/debugHelpers').toPointCloud
 
-const CAGMakers = require('./src/core/CAGFactories')
-CAG.fromSides = CAGMakers.fromSides
-CAG.fromObject = CAGMakers.fromObject
-CAG.fromPoints = CAGMakers.fromPoints
-CAG.fromPointsNoCheck = CAGMakers.fromPointsNoCheck
-CAG.fromPath2 = CAGMakers.fromPath2
-CAG.fromFakeCSG = CAGMakers.fromFakeCSG
+const CAGFactories = require('./src/core/CAGFactories')
+CAG.fromSides = CAGFactories.fromSides
+CAG.fromObject = CAGFactories.fromObject
+CAG.fromPoints = CAGFactories.fromPoints
+CAG.fromPointsNoCheck = CAGFactories.fromPointsNoCheck
+CAG.fromPath2 = CAGFactories.fromPath2
+CAG.fromFakeCSG = CAGFactories.fromFakeCSG
+CAG.fromCompactBinary = CAGFactories.fromCompactBinary
 
 /// ////////////////////////////////////
 // option parsers

--- a/src/core/CAGFactories.js
+++ b/src/core/CAGFactories.js
@@ -1,6 +1,6 @@
 const Side = require('./math/Side')
 const Vector2D = require('./math/Vector2')
-const Vertex = require('./math/Vertex2')
+const Vertex2 = require('./math/Vertex2')
 const {areaEPS} = require('./constants')
 const {isSelfIntersecting} = require('./utils/cagValidation')
 
@@ -39,10 +39,10 @@ const fromPoints = function (points) {
   if (numpoints < 3) throw new Error('CAG shape needs at least 3 points')
   let sides = []
   let prevpoint = new Vector2D(points[numpoints - 1])
-  let prevvertex = new Vertex(prevpoint)
+  let prevvertex = new Vertex2(prevpoint)
   points.map(function (p) {
     let point = new Vector2D(p)
-    let vertex = new Vertex(point)
+    let vertex = new Vertex2(point)
     let side = new Side(prevvertex, vertex)
     sides.push(side)
     prevvertex = vertex
@@ -86,10 +86,10 @@ const fromObject = function (obj) {
 const fromPointsNoCheck = function (points) {
   let sides = []
   let prevpoint = new Vector2D(points[points.length - 1])
-  let prevvertex = new Vertex(prevpoint)
+  let prevvertex = new Vertex2(prevpoint)
   points.map(function (p) {
     let point = new Vector2D(p)
-    let vertex = new Vertex(point)
+    let vertex = new Vertex2(point)
     let side = new Side(prevvertex, vertex)
     sides.push(side)
     prevvertex = vertex
@@ -107,11 +107,43 @@ const fromPath2 = function (path) {
   return fromPoints(path.getPoints())
 }
 
+/** Reconstruct a CAG from the output of toCompactBinary().
+ * @param {CompactBinary} bin - see toCompactBinary()
+ * @returns {CAG} new CAG object
+ */
+const fromCompactBinary = function (bin) {
+  if (bin['class'] !== 'CAG') throw new Error('Not a CAG')
+  let vertices = []
+  let vertexData = bin.vertexData
+  let numvertices = vertexData.length / 2
+  let arrayindex = 0
+  for (let vertexindex = 0; vertexindex < numvertices; vertexindex++) {
+    let x = vertexData[arrayindex++]
+    let y = vertexData[arrayindex++]
+    let pos = new Vector2D(x, y)
+    let vertex = new Vertex2(pos)
+    vertices.push(vertex)
+  }
+  let sides = []
+  let numsides = bin.sideVertexIndices.length / 2
+  arrayindex = 0
+  for (let sideindex = 0; sideindex < numsides; sideindex++) {
+    let vertexindex0 = bin.sideVertexIndices[arrayindex++]
+    let vertexindex1 = bin.sideVertexIndices[arrayindex++]
+    let side = new Side(vertices[vertexindex0], vertices[vertexindex1])
+    sides.push(side)
+  }
+  let cag = fromSides(sides)
+  cag.isCanonicalized = true
+  return cag
+}
+
 module.exports = {
   fromSides,
   fromObject,
   fromPoints,
   fromPointsNoCheck,
   fromPath2,
-  fromFakeCSG
+  fromFakeCSG,
+  fromCompactBinary
 }

--- a/test/cag-conversions.js
+++ b/test/cag-conversions.js
@@ -1,12 +1,11 @@
 import test from 'ava'
-import {CSG} from '../csg'
 import {CAG} from '../csg'
 
 //
 // Test suite for CAG Conversions
 //
 
-test.failing('CAG should convert to and from binary', t => {
+test('CAG should convert to and from binary', t => {
   // test using simple default shapes
   // In the current form this test cannot be working, something comparing
   // sides one by one should be written as objects differs

--- a/test/cag-conversions.js
+++ b/test/cag-conversions.js
@@ -1,5 +1,6 @@
-import test from 'ava'
-import {CAG} from '../csg'
+const test = require('ava')
+const {CAG} = require('../csg')
+const clearTags = require('./helpers/clearTags')
 
 //
 // Test suite for CAG Conversions
@@ -10,23 +11,23 @@ test('CAG should convert to and from binary', t => {
   // In the current form this test cannot be working, something comparing
   // sides one by one should be written as objects differs
 
-  var c1 = CAG.circle()
-  var c2 = CAG.ellipse()
-  var c3 = CAG.rectangle()
-  var c4 = CAG.roundedRectangle()
+  const c1 = CAG.circle()
+  const c2 = CAG.ellipse()
+  const c3 = CAG.rectangle()
+  const c4 = CAG.roundedRectangle()
 
-  var b1 = c1.toCompactBinary()
-  var r1 = CAG.fromCompactBinary(b1)
-  t.deepEqual(c1, r1)
-  var b2 = c2.toCompactBinary()
-  var r2 = CAG.fromCompactBinary(b2)
-  t.deepEqual(c2, r2)
-  var b3 = c3.toCompactBinary()
-  var r3 = CAG.fromCompactBinary(b3)
-  t.deepEqual(c3, r3)
-  var b4 = c4.toCompactBinary()
-  var r4 = CAG.fromCompactBinary(b4)
-  t.deepEqual(c4, r4)
+  const b1 = c1.toCompactBinary()
+  const r1 = CAG.fromCompactBinary(b1)
+  t.deepEqual(clearTags(c1), r1)
+  const b2 = c2.toCompactBinary()
+  const r2 = CAG.fromCompactBinary(b2)
+  t.deepEqual(clearTags(c2), r2)
+  const b3 = c3.toCompactBinary()
+  const r3 = CAG.fromCompactBinary(b3)
+  t.deepEqual(clearTags(c3), r3)
+  const b4 = c4.toCompactBinary()
+  const r4 = CAG.fromCompactBinary(b4)
+  t.deepEqual(clearTags(c4), r4)
 })
 
 test('CAG should convert to and from anonymous object', t => {

--- a/test/helpers/clearTags.js
+++ b/test/helpers/clearTags.js
@@ -1,0 +1,13 @@
+/** helper function to remove the very variable 'tags' fields from a CAG object
+ * @param  {CAG} input CAG 
+ * @returns {CAG} the MUTATED CAG
+ **/
+const clearTags = inputCAG => {
+  inputCAG.sides = inputCAG.sides.map(function (side) {
+    delete side.vertex0.tag
+    delete side.vertex1.tag
+    return side
+  })
+  return inputCAG
+}
+module.exports = clearTags


### PR DESCRIPTION
This PR fixes a MAJOR regression introduced in the last release that broke CAG.fromCompactBinary