### PR TITLE
remove quoted paths for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "main": "csg.js",
   "scripts": {
     "build-docs": "./node_modules/.bin/jsdoc -c jsdoc.json",
-    "docs": "jsdoc2md --files 'src/**/*.js' > docs/api.md",
-    "test-api": "nyc ava './src/**/*.test.js' --concurrency 3  --verbose --timeout 40000",
-    "test-core": "nyc ava './test' --concurrency 3  --verbose --timeout 40000",
+    "docs": "jsdoc2md --files src/**/*.js > docs/api.md",
+    "test-api": "nyc ava ./src/**/*.test.js --concurrency 3  --verbose --timeout 40000",
+    "test-core": "nyc ava ./test --concurrency 3  --verbose --timeout 40000",
     "test": "npm run test-core && npm run test-api",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "preversion": "npm test",


### PR DESCRIPTION
The quotes must be escaped under windows, as there are no spaces in the paths, they are not essential.