### PR TITLE
Fix/polygone(): params custom paths

### DIFF
--- a/src/api/primitives2d-api.js
+++ b/src/api/primitives2d-api.js
@@ -77,6 +77,8 @@ function circle (params) {
  * let poly = polygon({ points: roof, path: [0, 1, 2] })
  * or
  * let poly = polygon({ points: [roof, wall], path: [[0, 1, 2], [3, 4, 5, 6]] })
+ * or
+ * let poly = polygon({ points: roof.concat(wall), paths: [[0, 1, 2], [3, 4, 5], [3, 6, 5]] })
  */
 function polygon (params) { // array of po(ints) and pa(ths)
   let points = []

--- a/src/api/primitives2d-api.js
+++ b/src/api/primitives2d-api.js
@@ -72,17 +72,14 @@ function circle (params) {
  * let poly = polygon({path: [0,1,2,3,4], points: [2,1,3]})
  */
 function polygon (params) { // array of po(ints) and pa(ths)
-  let points = [ ]
+  let points = []
   if (params.paths && params.paths.length && params.paths[0].length) { // pa(th): [[0,1,2],[2,3,1]] (two paths)
-    for (let j = 0; j < params.paths.length; j++) {
-      for (let i = 0; i < params.paths[j].length; i++) {
-        points[i] = params.points[params.paths[j][i]]
-      }
-    }
+    params.paths.forEach((path, i) => {
+      points.push([])
+      path.forEach(j => points[i].push(params.points[j]))
+    })
   } else if (params.paths && params.paths.length) { // pa(th): [0,1,2,3,4] (single path)
-    for (let i = 0; i < params.paths.length; i++) {
-      points[i] = params.points[params.paths[i]]
-    }
+    params.paths.forEach(i => points.push(params.points[i]))
   } else { // pa(th) = po(ints)
     if (params.length) {
       points = params

--- a/src/api/primitives2d-api.js
+++ b/src/api/primitives2d-api.js
@@ -81,6 +81,9 @@ function circle (params) {
 function polygon (params) { // array of po(ints) and pa(ths)
   let points = []
   if (params.paths && params.paths.length && params.paths[0].length) { // pa(th): [[0,1,2],[2,3,1]] (two paths)
+    if (typeof params.points[0][0] !== 'number') { // flatten points array
+      params.points = params.points.reduce((a, b) => a.concat(b))
+    }
     params.paths.forEach((path, i) => {
       points.push([])
       path.forEach(j => points[i].push(params.points[j]))

--- a/src/api/primitives2d-api.js
+++ b/src/api/primitives2d-api.js
@@ -55,21 +55,28 @@ function circle (params) {
   return CAG.circle({center: offset, radius: r, resolution: fn})
 }
 
-/** Construct a polygon either from arrays of paths and points, or just arrays of points
- * nested paths (multiple paths) and flat paths are supported
- * @param {Object} [options] - options for construction
- * @param {Array} [options.paths] - paths of the polygon : either flat or nested array
- * @param {Array} [options.points] - points of the polygon : either flat or nested array
+/** Construct a polygon either from arrays of paths and points,
+ * or just arrays of points nested paths (multiple paths) and flat paths are supported
+ * @param {Object} [options] - options for construction or either flat or nested array of points
+ * @param {Array} [options.points] - points of the polygon : either flat or nested array of points
+ * @param {Array} [options.paths] - paths of the polygon : either flat or nested array of points index
  * @returns {CAG} new polygon
  *
  * @example
- * let poly = polygon([0,1,2,3,4])
+ * let roof = [[10,11], [0,11], [5,20]]
+ * let wall = [[0,0], [10,0], [10,10], [0,10]]
+ *
+ * let poly = polygon(roof)
  * or
- * let poly = polygon([[0,1,2,3],[4,5,6,7]])
+ * let poly = polygon([roof, wall])
  * or
- * let poly = polygon({path: [0,1,2,3,4]})
+ * let poly = polygon({ points: roof })
  * or
- * let poly = polygon({path: [0,1,2,3,4], points: [2,1,3]})
+ * let poly = polygon({ points: [roof, wall] })
+ * or
+ * let poly = polygon({ points: roof, path: [0, 1, 2] })
+ * or
+ * let poly = polygon({ points: [roof, wall], path: [[0, 1, 2], [3, 4, 5, 6]] })
  */
 function polygon (params) { // array of po(ints) and pa(ths)
   let points = []

--- a/src/api/primitives2d.test.js
+++ b/src/api/primitives2d.test.js
@@ -283,15 +283,23 @@ test('polygon (object params)', t => {
   t.truthy(comparePositonVertices(obs.sides, expSides))
 })
 
-test.failing('polygon (object params, with custom paths)', t => {
-  const obs = polygon({points: [ [0, 0], [3, 0], [3, 3] ], paths: [ [0, 1, 2], [1, 2, 3] ]})
+test('polygon (object params, with custom paths)', t => {
+  const roof = [[10,11], [0,11], [5,20]]
+  const wall = [[0,0], [10,0], [10,10], [0,10]]
+  const obs = polygon({ points: [roof, wall], paths: [[0, 1, 2], [3, 4, 5, 6]] })
 
-  const expSides = [ [ [ 3, 3 ], [ 0, 0 ] ],
-    [ [ 0, 0 ], [ 3, 0 ] ],
-    [ [ 3, 0 ], [ 3, 3 ] ]
+  const expSides = [
+    [ [0.00000,10.00000], [0.00000,0.00000] ],
+    [ [0.00000,0.00000], [10.00000,0.00000] ],
+    [ [10.00000,0.00000], [10.00000,10.00000] ],
+    [ [10.00000,10.00000], [0.00000,10.00000] ],
+    [ [5.00000,20.00000], [0.00000,11.00000] ],
+    [ [0.00000,11.00000], [10.00000,11.00000] ],
+    [ [10.00000,11.00000], [5.00000,20.00000] ]
   ]
+
   // we just use a sample of points for simplicity
-  t.deepEqual(obs.sides.length, 3)
+  t.deepEqual(obs.sides.length, 7)
   t.truthy(comparePositonVertices(obs.sides, expSides))
 })
 


### PR DESCRIPTION
```javascript
function main(params) {
    let roof = [[10,11], [0,11], [5,20]];
    let wall = [[0,0], [10,0], [10,10], [0,10]];
    let door = [[4,0], [6,0], [6,5], [4,5]];
    let win = [[4,6], [6,6], [6,8], [4,8]];
    
    let poly1 = polygon(roof);
    let poly2 = polygon([roof, wall]);
    let poly3 = polygon({ points: roof });
    let poly4 = polygon({ points: [roof, wall] });
    let poly5 = polygon({ points: roof, paths: [0, 1, 2] });
    let poly6 = polygon({ points: [roof, wall], paths: [[0, 1, 2], [3, 4, 5, 6]] });
    let poly7 = polygon({ points: roof.concat(wall), paths: [[0, 1, 2], [3, 4, 5], [3, 6, 5]] });
    
    let poly8 = polygon([roof, wall, door, win]);
    
    return [
        poly1.translate([20, 0, 0]),
        poly2.translate([40, 0, 0]),
        poly3.translate([60, 0, 0]),
        poly4.translate([80, 0, 0]),
        poly5.translate([100, 0, 0]),
        poly6.translate([120, 0, 0]),
        poly7.translate([140, 0, 0]),
        poly8.translate([160, 0, 0])
    ];
}
```
![jscad](https://user-images.githubusercontent.com/796149/39127153-77851aa4-4704-11e8-93b7-936707e4c87b.png)
