### PR TITLE
Fix and Tests for CAG measurements and Poly3 measurements

### DIFF
--- a/src/core/math/Polygon3.js
+++ b/src/core/math/Polygon3.js
@@ -1,6 +1,7 @@
 const Vector3D = require('./Vector3')
 const Vertex = require('./Vertex3')
 const Matrix4x4 = require('./Matrix4')
+const measureArea = require('./measureArea')
 const {_CSGDEBUG, EPS, getTag, areaEPS} = require('../constants')
 
 /** Class Polygon
@@ -75,15 +76,8 @@ Polygon.prototype = {
     return signedVolume
   },
 
-    // Note: could calculate vectors only once to speed up
   getArea: function () {
-    let polygonArea = 0
-    for (let i = 0; i < this.vertices.length - 2; i++) {
-      polygonArea += this.vertices[i + 1].pos.minus(this.vertices[0].pos)
-                .cross(this.vertices[i + 2].pos.minus(this.vertices[i + 1].pos)).length()
-    }
-    polygonArea /= 2
-    return polygonArea
+    return measureArea(this)
   },
 
     // accepts array of features to calculate

--- a/src/core/math/measureArea.js
+++ b/src/core/math/measureArea.js
@@ -1,0 +1,77 @@
+
+// measure the area of the given poly3 (3D planar polygon)
+// translated from the orginal C++ code from Dan Sunday
+// 2000 softSurfer http://geomalgorithms.com
+const measureArea = (poly3) => {
+  let n = poly3.vertices.length
+  if (n < 3) {
+    return 0 // degenerate polygon
+  }
+  let vertices = poly3.vertices
+
+// calculate a real normal
+  let a = vertices[0].pos
+  let b = vertices[1].pos
+  let c = vertices[2].pos
+  let normal = b.minus(a).cross(c.minus(a))
+  //let normal = poly3.plane.normal // unit based normal, CANNOT use
+
+// determin direction of projection
+  let ax = Math.abs(normal._x)
+  let ay = Math.abs(normal._y)
+  let az = Math.abs(normal._z)
+  let an = Math.sqrt( (ax * ax) + (ay * ay) + (az * az)) // length of normal
+
+  let coord = 3 // ignore Z coordinates
+  if ((ax > ay) && (ax > az)) {
+    coord = 1 // ignore X coordinates
+  } else
+  if (ay > az) {
+    coord = 2 // ignore Y coordinates
+  }
+
+  let area = 0
+  let h = 0
+  let i = 1
+  let j = 2
+  switch (coord) {
+    case 1: // ignore X coordinates
+    // compute area of 2D projection
+      for (i = 1; i < n; i++) {
+        h = i - 1
+        j = (i + 1) % n
+        area += (vertices[i].pos._y * (vertices[j].pos._z - vertices[h].pos._z))
+      }
+      area += (vertices[0].pos._y * (vertices[1].pos._z - vertices[n - 1].pos._z))
+    // scale to get area
+      area *= (an / (2 * normal._x))
+      break
+
+    case 2: // ignore Y coordinates
+    // compute area of 2D projection
+      for (i = 1; i < n; i++) {
+        h = i - 1
+        j = (i + 1) % n
+        area += (vertices[i].pos._z * (vertices[j].pos._x - vertices[h].pos._x))
+      }
+      area += (vertices[0].pos._z * (vertices[1].pos._x - vertices[n - 1].pos._x))
+    // scale to get area
+      area *= (an / (2 * normal._y))
+      break
+
+    case 3: // ignore Z coordinates
+    // compute area of 2D projection
+      for (i = 1; i < n; i++) {
+        h = i - 1
+        j = (i + 1) % n
+        area += (vertices[i].pos._x * (vertices[j].pos._y - vertices[h].pos._y))
+      }
+      area += (vertices[0].pos._x * (vertices[1].pos._y - vertices[n - 1].pos._y))
+    // scale to get area
+      area *= (an / (2 * normal._z))
+      break
+  }
+  return area
+}
+
+module.exports = measureArea

--- a/src/core/utils/cagMeasurements.js
+++ b/src/core/utils/cagMeasurements.js
@@ -1,8 +1,8 @@
 const Vector2D = require('../math/Vector2')
 
-// see http://local.wasp.uwa.edu.au/~pbourke/geometry/polyarea/ :
-// Area of the polygon. For a counter clockwise rotating polygon the area is positive, otherwise negative
-// Note(bebbi): this looks wrong. See polygon getArea()
+// Calculate the area of the give CAG (a closed convex 2D polygon)
+// For a counter clockwise rotating polygon (about Z) the area is positive, otherwise negative.
+// See http://paulbourke.net/geometry/polygonmesh/
 const area = function (cag) {
   let polygonArea = 0
   cag.sides.map(function (side) {

--- a/test/cag-measurements.js
+++ b/test/cag-measurements.js
@@ -1,0 +1,100 @@
+import test from 'ava'
+import {CSG, CAG} from '../csg'
+import {nearlyEquals, CAGNearlyEquals} from './helpers/asserts'
+
+//
+// Test suite for CAG measurements
+// - verify measurements for new CAG ("empty")
+// - verify measurements for CAG primitives shapes
+// - verify measurements for complex CAG shapes
+//
+test('New CAG measurements', t => {
+  const cag = new CAG()
+
+// area
+  let area = cag.area()
+  t.is(area, 0)
+
+// bounds
+  let bounds = cag.getBounds()
+  let min = bounds[0]
+  t.is(min.x, 0)
+  t.is(min.y, 0)
+  let max = bounds[1]
+  t.is(max.x, 0)
+  t.is(max.y, 0)
+
+// center
+})
+
+test('CAG rectangle measurements', t => {
+  let cag1 = CAG.rectangle() // radius: 1
+
+// area
+  let area = cag1.area()
+  t.is(area, 4)
+
+// bounds
+  let bounds = cag1.getBounds()
+  let min = bounds[0]
+  t.is(min.x, -1)
+  t.is(min.y, -1)
+  let max = bounds[1]
+  t.is(max.x, 1)
+  t.is(max.y, 1)
+
+// and transformed
+  let cag2 = cag1.translate([5,5]).rotateZ(45)
+
+  area = cag2.area()
+  t.true(nearlyEquals(area, 4))
+})
+
+test('CAG circle measurements', t => {
+  let cag1 = CAG.circle() // radius: 1
+
+  let area = cag1.area()
+  t.true(nearlyEquals(area, 3.1214, 0.0001))
+
+  let cag2 = cag1.translate([5,5]).rotateZ(5)
+
+  area = cag2.area()
+  t.true(nearlyEquals(area, 3.1214, 0.0001))
+})
+
+test('CAG complex (multiple parts) measurements', t => {
+  let cag1 = CAG.rectangle() // radius: 1
+  let cag2 = cag1.union(cag1.translate([5,5]).rotateZ(45))
+
+  let area = cag2.area()
+  t.true(nearlyEquals(area, 8, 0.0001))
+})
+
+test('CAG complex (multiple hole) measurements', t => {
+  let cag1 = CAG.rectangle() // radius: 1
+  let cag2 = CAG.rectangle({radius: 10})
+  let cag3 = cag2.subtract(cag1.translate([5,5]).rotateZ(45))
+
+  let area = cag3.area()
+  t.true(nearlyEquals(area, 396, 0.0001))
+
+  let cag4 = cag3.subtract(cag1.translate([5,5]).rotateZ(-90))
+
+  area = cag4.area()
+  t.true(nearlyEquals(area, 392, 0.0001))
+
+  let cag10 = CAG.circle({radius: 25, resolution: 360})
+  area = cag10.area()
+  t.true(nearlyEquals(area, 1963.3957, 0.0001))
+
+  let cag11 = CAG.circle({radius: 3, resolution: 72, center: [5,5]})
+  area = cag11.area()
+  t.true(nearlyEquals(area, 28.2384, 0.0001))
+
+  let cag12 = cag10.subtract(cag11).subtract(cag11.rotateZ(180))
+
+  area = cag12.area()
+  t.true(nearlyEquals(area, 1906.9188, 0.0001))
+})
+
+

--- a/test/helpers/asserts.js
+++ b/test/helpers/asserts.js
@@ -78,6 +78,9 @@ function nearlyEquals (a, b, epsilon = 1) {
   var absA = Math.abs(a)
   var absB = Math.abs(b)
   var diff = Math.abs(a - b)
+  if (Number.isNaN(diff)) {
+    return false
+  }
   if (a === 0 || b === 0 || diff < Number.EPSILON) {
   // a or b is zero or both are extremely close to it
   // relative error is less meaningful here
@@ -118,5 +121,6 @@ module.exports = {
   comparePolygons,
   simplifiedPolygon,
   simplifieSides,
+  nearlyEquals,
   CAGNearlyEquals
 }


### PR DESCRIPTION
Additional tests were added to verify and test area calculations for both CAG and Polygon3.

Issues with Polygon3 were found when the polygon was 'concave' in shape. Fixes were made to use a faster routine for area calculations.

Note: measureArea.js was added for the new routine, which should be easy to integrate into V2.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests? (Including new tests)
