### PR TITLE
add hull() for 3D solids implemented by using quickhull3d package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "jscad"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "quickhull3d": "^2.0.4"
+  },
   "devDependencies": {
     "ava": "^0.23.0",
     "conventional-changelog-cli": "^1.3.4",


### PR DESCRIPTION
* the function still works with 2d objects
* `chain_hull` works, too