### PR TITLE
Vec2

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -9,7 +9,14 @@ const defaultResolution2D = 32 // FIXME this seems excessive
  */
 const defaultResolution3D = 12
 
+/** The resolution of space, currently one hundred nanometers.
+ *  This should be 1 / EPS.
+ * @default
+ */
+const spatialResolution = 1e5
+
 /** Epsilon used during determination of near zero distances.
+ *  This should be 1 / spacialResolution.
  * @default
  */
 const EPS = 1e-5

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -58,5 +58,6 @@ module.exports = {
   front,
   back,
   staticTag,
-  getTag
+  getTag,
+  spatialResolution
 }

--- a/src/core/math/vec2/canonicalize.js
+++ b/src/core/math/vec2/canonicalize.js
@@ -1,0 +1,8 @@
+const spatialResolution = require('../../constants').EPS;
+const fromValues = require('./fromValues');
+
+const quantize = (value) => (Math.round(value * spatialResolution) / spatialResolution)
+
+const canonicalize = (vector) => fromValues(quantize(vector[0]), quantize(vector[1]))
+
+module.exports = canonicalize

--- a/src/core/math/vec2/canonicalize.js
+++ b/src/core/math/vec2/canonicalize.js
@@ -1,4 +1,4 @@
-const spatialResolution = require('../../constants').EPS;
+const { spatialResolution } = require('../../constants')
 const fromValues = require('./fromValues');
 
 const quantize = (value) => (Math.round(value * spatialResolution) / spatialResolution)

--- a/src/core/math/vec2/canonicalize.test.js
+++ b/src/core/math/vec2/canonicalize.test.js
@@ -1,10 +1,15 @@
 const canonicalize = require('./canonicalize')
 const equals = require('./equals')
 const fromValues = require('./fromValues')
-const spatialResolution = require('../../constants').spatialResolution
 const test = require('ava')
 
-const piVec = fromValues(Math.PI, Math.PI);
+const piVec = fromValues(3.141592653589793, 3.141592653589793)
+
+// This test is intended to be illustrative, and establish ground truth
+// It will need to be updated if ../../constants.spatialResolution changes.
+test('vec2: Canonicalizion quantizes to spatial resolution', t => {
+  t.true(equals(canonicalize(piVec), fromValues(3.141590118408203, 3.141590118408203)))
+})
 
 test('vec2: Canonicalizion is transformative', t => {
   t.false(equals(piVec, canonicalize(piVec)));

--- a/src/core/math/vec2/canonicalize.test.js
+++ b/src/core/math/vec2/canonicalize.test.js
@@ -1,0 +1,15 @@
+const canonicalize = require('./canonicalize')
+const equals = require('./equals')
+const fromValues = require('./fromValues')
+const spatialResolution = require('../../constants').spatialResolution
+const test = require('ava')
+
+const piVec = fromValues(Math.PI, Math.PI);
+
+test('vec2: Canonicalizion is transformative', t => {
+  t.false(equals(piVec, canonicalize(piVec)));
+})
+
+test('vec2: Canonicalizion is idemponent', t => {
+  t.true(equals(canonicalize(piVec), canonicalize(canonicalize(piVec))));
+})

--- a/src/core/math/vec2/canonicalize.test.js
+++ b/src/core/math/vec2/canonicalize.test.js
@@ -7,14 +7,14 @@ const piVec = fromValues(3.141592653589793, 3.141592653589793)
 
 // This test is intended to be illustrative, and establish ground truth
 // It will need to be updated if ../../constants.spatialResolution changes.
-test('vec2: Canonicalizion quantizes to spatial resolution', t => {
+test('vec2: Canonicalization quantizes to spatial resolution', t => {
   t.true(equals(canonicalize(piVec), fromValues(3.141590118408203, 3.141590118408203)))
 })
 
-test('vec2: Canonicalizion is transformative', t => {
+test('vec2: Canonicalization is transformative', t => {
   t.false(equals(piVec, canonicalize(piVec)));
 })
 
-test('vec2: Canonicalizion is idemponent', t => {
+test('vec2: Canonicalization is idempotent', t => {
   t.true(equals(canonicalize(piVec), canonicalize(canonicalize(piVec))));
 })

--- a/src/core/math/vec2/index.js
+++ b/src/core/math/vec2/index.js
@@ -4,6 +4,7 @@ module.exports = {
   angle: require('./angle'),
   angleDegrees: require('./angleDegrees'),
   angleRadians: require('./angleRadians'),
+  canonicalize: require('./canonicalize'),
   clone: require('./clone'),
   create: require('./create'),
   cross: require('./cross'),


### PR DESCRIPTION
Canonicalization via EPS based deduplication leads to incremental creeping error and can bring geometries out of plane.

Quantization of space avoids this issue.

This adds support for a quantization of space to a resolution of 100 nm, which equals the current EPS threshold.

Initial support is added to vec2 via a canonicalization operation which rounds the vector components to the nearest 100 quantized value.