### PR TITLE
Simple tagged dispatch for alternative and external geometry implementation.

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,32 +1,6 @@
-
-const primitives3d = require('./primitives3d-api')
-const primitives2d = require('./primitives2d-api')
-const booleanOps = require('./booleans/ops-booleans')
-const transformations = require('./transformations/ops-transformations')
-const extrusions = require('./ops-extrusions')
-const color = require('./color')
-const maths = require('./maths')
-const text = require('./text')
-const { echo } = require('./debug')
-
-// these are 'external' to this api and we basically just re-export for old api compatibility
-// ...needs to be reviewed
-const { CAG, CSG } = require('../../csg')
-
 const exportedApi = {
-  csg: {CAG, CSG},
-  primitives2d,
-  primitives3d,
-  booleanOps,
-  transformations,
-  extrusions,
-  color,
-  maths,
-  text,
-  debug: {echo}
+  registerImplementation: require('./registerImplementation'),
+  toImplementation: require('./toImplementation')
 }
-
-// easier to access
-// const flatApi = Object.assign({}, primitives2d, primitives3d, booleanOps, transformations, extrusions, color, text)
 
 module.exports = exportedApi

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,32 @@
+
+const primitives3d = require('./primitives3d-api')
+const primitives2d = require('./primitives2d-api')
+const booleanOps = require('./booleans/ops-booleans')
+const transformations = require('./transformations/ops-transformations')
+const extrusions = require('./ops-extrusions')
+const color = require('./color')
+const maths = require('./maths')
+const text = require('./text')
+const { echo } = require('./debug')
+
+// these are 'external' to this api and we basically just re-export for old api compatibility
+// ...needs to be reviewed
+const { CAG, CSG } = require('../../csg')
+
 const exportedApi = {
-  registerImplementation: require('./registerImplementation'),
-  toImplementation: require('./toImplementation')
+  csg: {CAG, CSG},
+  primitives2d,
+  primitives3d,
+  booleanOps,
+  transformations,
+  extrusions,
+  color,
+  maths,
+  text,
+  debug: {echo}
 }
+
+// easier to access
+// const flatApi = Object.assign({}, primitives2d, primitives3d, booleanOps, transformations, extrusions, color, text)
 
 module.exports = exportedApi

--- a/src/api/registerImplementation.js
+++ b/src/api/registerImplementation.js
@@ -1,0 +1,30 @@
+/**
+ * Registers an implementation with a tag for use with implementationOf.
+ *
+ * This function is functionally sound -- the result is invariant for any
+ *   provided (tag, module) pair.
+ *
+ * The caller can test the result of the function against the module provided
+ *   to see what registerImplementation will always return when provided
+ *   that tag.
+ *
+ * @params {string} tag - tag associated with the module.
+ * @params {Object} module - the module to test the association of with the tag.
+ * @example
+ * (registerImplementation('foo', bar) === bar
+ */
+ 
+// The global registry.
+const implementationRegistry = {}
+
+const registerImplementation = (tag, module) => {
+  const registeredModule = implementationRegistry[tag];
+  if (registeredModule === undefined) {
+    implementationRegistry[tag] = module
+  }
+
+  // Caller can check if the module returned matches the module passed.
+  return implementationRegistry[tag]
+}
+
+module.exports = registerImplementation

--- a/src/api/registerImplementation.test.js
+++ b/src/api/registerImplementation.test.js
@@ -1,0 +1,11 @@
+const registerImplementation = require('./registerImplementation')
+const test = require('ava')
+
+test('registerImplementation is idempotent', t => {
+  const tag = 'tag'
+  const module1 = {}
+  const module2 = {}
+
+  t.is(registerImplementation(tag, module1), module1)
+  t.is(registerImplementation(tag, module2), module1)
+})

--- a/src/api/registry/index.js
+++ b/src/api/registry/index.js
@@ -1,0 +1,6 @@
+const exportedApi = {
+  registerImplementation: require('./registerImplementation'),
+  toImplementation: require('./toImplementation')
+}
+
+module.exports = exportedApi

--- a/src/api/registry/registerImplementation.js
+++ b/src/api/registry/registerImplementation.js
@@ -11,7 +11,7 @@
  * @params {string} tag - tag associated with the module.
  * @params {Object} module - the module to test the association of with the tag.
  * @example
- * (registerImplementation('foo', bar) === bar
+ * registerImplementation('foo', bar) === bar
  */
  
 // The global registry.

--- a/src/api/registry/registerImplementation.js
+++ b/src/api/registry/registerImplementation.js
@@ -1,0 +1,30 @@
+/**
+ * Registers an implementation with a tag for use with implementationOf.
+ *
+ * This function is functionally sound -- the result is invariant for any
+ *   provided (tag, module) pair.
+ *
+ * The caller can test the result of the function against the module provided
+ *   to see what registerImplementation will always return when provided
+ *   that tag.
+ *
+ * @params {string} tag - tag associated with the module.
+ * @params {Object} module - the module to test the association of with the tag.
+ * @example
+ * (registerImplementation('foo', bar) === bar
+ */
+ 
+// The global registry.
+const implementationRegistry = {}
+
+const registerImplementation = (tag, module) => {
+  const registeredModule = implementationRegistry[tag];
+  if (registeredModule === undefined) {
+    implementationRegistry[tag] = module
+  }
+
+  // Caller can check if the module returned matches the module passed.
+  return implementationRegistry[tag]
+}
+
+module.exports = registerImplementation

--- a/src/api/registry/registerImplementation.test.js
+++ b/src/api/registry/registerImplementation.test.js
@@ -1,0 +1,11 @@
+const registerImplementation = require('./registerImplementation')
+const test = require('ava')
+
+test('registerImplementation is idempotent', t => {
+  const tag = 'tag'
+  const module1 = {}
+  const module2 = {}
+
+  t.is(registerImplementation(tag, module1), module1)
+  t.is(registerImplementation(tag, module2), module1)
+})

--- a/src/api/registry/toImplementation.js
+++ b/src/api/registry/toImplementation.js
@@ -1,0 +1,24 @@
+const registerImplementation = require('./registerImplementation')
+
+/**
+ * Returns the module implementing a geometry based on a field named
+ *   __jscadTag__.
+ *
+ * This function is functionally sound, and will always produce the same module
+ * for the same tag.
+ *
+ * For this reason it implicitly register the nullModule if no module has been
+ *   registered.
+ *
+ * @params {geometry} geometry - the geometry to find the implementation of.
+ * @returns {Object} module - the module implementing the geometry.
+ * @example
+ * implementationOf(box).eachPoint({}, collectBounds, box)
+ */
+
+// 
+const nullModule = {}
+
+const toImplementation = geometry => registerImplementation(geometry.__jscadTag__, nullModule)
+
+module.exports = toImplementation

--- a/src/api/registry/toImplementation.test.js
+++ b/src/api/registry/toImplementation.test.js
@@ -1,0 +1,18 @@
+const getImplementation = require('./getImplementation')
+const registerImplementation = require('./registerImplementation')
+const test = require('ava')
+
+test('implementationOf is idempotent', t => {
+  const tag = 'tag'
+  const module = {}
+  const object = { __jscadTag__: tag }
+
+  t.is(registerImplementation(tag, module), module)
+  t.is(getImplementation(object), module)
+})
+
+test('implementationOf defaults to a consistent null module', t => {
+  const module = getImplementation({ __jscadTag__: 'tag_1' })
+
+  t.is(getImplementation({ __jscadTag__: 'tag_2'}), module)
+})

--- a/src/api/toImplementation.js
+++ b/src/api/toImplementation.js
@@ -1,0 +1,24 @@
+const registerImplementation = require('./registerImplementation')
+
+/**
+ * Returns the module implementing a geometry based on a field named
+ *   __jscadTag__.
+ *
+ * This function is functionally sound, and will always produce the same module
+ * for the same tag.
+ *
+ * For this reason it implicitly register the nullModule if no module has been
+ *   registered.
+ *
+ * @params {geometry} geometry - the geometry to find the implementation of.
+ * @returns {Object} module - the module implementing the geometry.
+ * @example
+ * implementationOf(box).eachPoint({}, collectBounds, box)
+ */
+
+// 
+const nullModule = {}
+
+const toImplementation = geometry => registerImplementation(geometry.__jscadTag__, nullModule)
+
+module.exports = toImplementation

--- a/src/api/toImplementation.test.js
+++ b/src/api/toImplementation.test.js
@@ -1,0 +1,18 @@
+const getImplementation = require('./getImplementation')
+const registerImplementation = require('./registerImplementation')
+const test = require('ava')
+
+test('implementationOf is idempotent', t => {
+  const tag = 'tag'
+  const module = {}
+  const object = { __jscadTag__: tag }
+
+  t.is(registerImplementation(tag, module), module)
+  t.is(getImplementation(object), module)
+})
+
+test('implementationOf defaults to a consistent null module', t => {
+  const module = getImplementation({ __jscadTag__: 'tag_1' })
+
+  t.is(getImplementation({ __jscadTag__: 'tag_2'}), module)
+})


### PR DESCRIPTION
This allows alternative or externally defined geometries to be used with the jscad api.

A geometry module should add something like.

const registerImplementation = require('.../registerImplementation')
const __jscadTag__ = 'some-unique-identifier'

registerImplementation(__jscadTag__, module)

And produce objects which carry { __jscadTag__: __jscadTag }.

Once that module is imported toImplementation(object) will produce that module, allowing constructions like.

toImplementation(object).eachPoint({}, fun, object)

See design in:
https://docs.google.com/document/d/1nz7dhtErHBqBpuFcu7ooRU91miVTD4UxiJ6od1TbUgs/edit#