### PR TITLE
math/line3 is broken

### DIFF
--- a/src/core/math/line3/equals.js
+++ b/src/core/math/line3/equals.js
@@ -3,13 +3,16 @@ const vec3 = require('../vec3')
 /**
  * Compare the given 3D lines for equality
  *
+ * FIX: This does not compare lines for equality.
+ *
  * @return {boolean} true if lines are equal
  */
 const equals = (line1, line2) => {
   // compare directions (unit vectors)
   if (!vec3.equals(line1[1], line2[1])) return false
 
-  // compare points
+  // FIX: This is wrong -- it will compare false for any two distinct points
+  // on the line.
   if (!vec3.equals(line1[0], line2[0])) return false
 
   // why would lines with the same slope (direction) and different points be equal?


### PR DESCRIPTION
math/line3 seems to be confused between lines and vectors on lines and line segments.

In particular line3 equals is wrong -- two mathematically equal lines will generally compare false.

I think we need to decide what line3 is trying to describe before fixing it.