### PR TITLE
V2 - Fix of Rotate

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build-docs": "./node_modules/.bin/jsdoc -c jsdoc.json",
     "docs": "jsdoc2md --files src/**/*.js > docs/api.md",
-    "test": "nyc ava **/*.test.js --concurrency 3  --verbose --timeout 40000",
+    "test": "nyc ava 'src/**/*.test.js' --concurrency 3  --verbose --timeout 40000",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "preversion": "npm test",
     "version": "npm run changelog && npm run docs && git add -A ",

--- a/src/operations/transforms/rotate.js
+++ b/src/operations/transforms/rotate.js
@@ -6,7 +6,7 @@ const { geom2, geom3, path2 } = require('../../geometry')
 
 /**
  * Rotate the given object(s) using the given options (if any)
- * @param {Array} angles - angle of rotations about X, Y, and X axis
+ * @param {[x,y,y]} angles - angle (RADIANS) of rotations about X, Y, and X axis
  * @param {Object|Array} objects - the objects(s) to rotate
  * @return {Object|Array} the rotated object(s)
  *
@@ -20,10 +20,9 @@ const rotate = (angles, ...objects) => {
   objects = flatten(objects)
   if (objects.length === 0) throw new Error('wrong number of arguments')
 
-  // convert to radians
-  let yaw = angles[2] * Math.PI * (1.0 / 180.0)
-  let pitch = angles[1] * Math.PI * (1.0 / 180.0)
-  let roll = angles[0] * Math.PI * (1.0 / 180.0)
+  let yaw = angles[2]
+  let pitch = angles[1]
+  let roll = angles[0]
 
   const matrix = mat4.fromTaitBryanRotation(yaw, pitch, roll)
 

--- a/src/operations/transforms/rotate.test.js
+++ b/src/operations/transforms/rotate.test.js
@@ -10,7 +10,7 @@ test('rotate: rotating of a path2 produces expected changes to points', t => {
   let geometry = path2.fromPoints({}, [[1, 0], [0, 1], [-1, 0]])
 
   // rotate about Z
-  let rotated = rotate([0, 0, 90], geometry)
+  let rotated = rotate([0, 0, Math.PI/2], geometry)
   let obs = path2.toPoints(rotated)
   let exp = [
     new Float32Array([ 0, 1 ]),
@@ -19,7 +19,7 @@ test('rotate: rotating of a path2 produces expected changes to points', t => {
   ]
   t.true(comparePoints(obs, exp))
 
-  rotated = rotateZ(90, geometry)
+  rotated = rotateZ(Math.PI/2, geometry)
   obs = path2.toPoints(rotated)
   t.true(comparePoints(obs, exp))
 })
@@ -28,7 +28,7 @@ test('rotate: rotating of a geom2 produces expected changes to points', t => {
   let geometry = geom2.fromPoints([[0, 0], [1, 0], [0, 1]])
 
   // rotate about Z
-  let rotated = rotate([0, 0, -90], geometry)
+  let rotated = rotate([0, 0, -Math.PI/2], geometry)
   let obs = geom2.toPoints(rotated)
   let exp = [
     new Float32Array([0, 0]),
@@ -37,7 +37,7 @@ test('rotate: rotating of a geom2 produces expected changes to points', t => {
   ]
   t.true(comparePoints(obs, exp))
 
-  rotated = rotateZ(-90, geometry)
+  rotated = rotateZ(-Math.PI/2, geometry)
   obs = geom2.toPoints(rotated)
   t.true(comparePoints(obs, exp))
 })
@@ -54,7 +54,7 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', t => {
   let geometry = geom3.fromPoints(points)
 
   // rotate about X
-  let rotated = rotate([90, 0, 0], geometry)
+  let rotated = rotate([Math.PI/2, 0, 0], geometry)
   let obs = geom3.toPoints(rotated)
   let exp = [
     [ new Float32Array([ -2, 12, -7 ]), new Float32Array([ -2, -18, -7 ]),
@@ -72,12 +72,12 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', t => {
   ]
   t.deepEqual(obs, exp)
 
-  rotated = rotateX(90, geometry)
+  rotated = rotateX(Math.PI/2, geometry)
   obs = geom3.toPoints(rotated)
   t.deepEqual(obs, exp)
 
   // rotate about Y
-  rotated = rotate([0, -90, 0], geometry)
+  rotated = rotate([0, -Math.PI/2, 0], geometry)
   obs = geom3.toPoints(rotated)
   exp = [
     [ new Float32Array([ 12, -7, -2 ]), new Float32Array([ -18, -7, -2 ]),
@@ -95,12 +95,12 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', t => {
   ]
   t.deepEqual(obs, exp)
 
-  rotated = rotateY(-90, geometry)
+  rotated = rotateY(-Math.PI/2, geometry)
   obs = geom3.toPoints(rotated)
   t.deepEqual(obs, exp)
 
   // rotate about Z
-  rotated = rotate([0, 0, 180], geometry)
+  rotated = rotate([0, 0, Math.PI], geometry)
   obs = geom3.toPoints(rotated)
   exp = [
     [ new Float32Array([ 2, 7, -12 ]), new Float32Array([ 2, 7, 18 ]),
@@ -118,7 +118,7 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', t => {
   ]
   t.deepEqual(obs, exp)
 
-  rotated = rotateZ(180, geometry)
+  rotated = rotateZ(Math.PI, geometry)
   obs = geom3.toPoints(rotated)
   t.deepEqual(obs, exp)
 })
@@ -128,7 +128,7 @@ test('rotate: rotating of multiple objects produces expected changes', t => {
   let geometry1 = path2.fromPoints({}, [[-5, 5], [5, 5], [-5, -5], [10, -5]])
   let geometry2 = geom2.fromPoints([[-5, -5], [0, 5], [10, -5]])
 
-  let rotated = rotate([0, 0, 90], junk, geometry1, geometry2)
+  let rotated = rotate([0, 0, Math.PI/2], junk, geometry1, geometry2)
 
   t.is(rotated[0], junk)
 


### PR DESCRIPTION
It seems that rotate() was completd before we committed on RADIANS for all angles.
This pull request corrects that little error, and adjusts the test suites.

rotate:
- [X] code complete
- [X] test complete
- [X] review complete

P.S. I also fixed the GLOB parameter to ava in package.json. Way overdue.