### PR TITLE
V2 : Enable torus primitive

### DIFF
--- a/src/primitives/index.js
+++ b/src/primitives/index.js
@@ -18,5 +18,5 @@ module.exports = {
   sphere: require('./ellipsoid').sphere,
   square: require('./rectangle').square,
   star: require('./star'),
-//  torus: require('./torus')
+  torus: require('./torus')
 }

--- a/src/primitives/torus.js
+++ b/src/primitives/torus.js
@@ -1,19 +1,22 @@
-const {extrudeRotate, rotateZ} = require('../operations')
+const {extrudeRotate} = require('../operations/extrusions')
+const {rotateZ} = require('../operations/transforms')
 
 const {circle} = require('./ellipse')
 
-/** Construct a torus by revolving a small circle (inner) about the circumference of a large (outer) circle.
+/**
+ * Construct a torus by revolving a small circle (inner) about the circumference of a large (outer) circle.
  * @param {Object} [options] - options for construction
  * @param {Float} [options.innerRadius=1] - radius of small (inner) circle
  * @param {Float} [options.outerRadius=4] - radius of large (outer) circle
- * @param {Integer} [options.innerSegments=16] - number of segments to create per 360 rotation
- * @param {Integer} [options.outerSegments=12] - number of segments to create per 360 rotation
+ * @param {Integer} [options.innerSegments=16] - number of segments to create per rotation
+ * @param {Integer} [options.outerSegments=12] - number of segments to create per rotation
  * @param {Integer} [options.innerRotation=0] - rotation of small (inner) circle in radians
  * @returns {geom3} new 3D geometry
  *
  * @example
  * let torus1 = torus({
- *   innerRadius: 10
+ *   innerRadius: 10,
+ *   outerRadius: 100
  * })
  */
 const torus = (options) => {
@@ -34,7 +37,7 @@ const torus = (options) => {
 
   options = {
     startAngle: 0,
-    angle: 360,
+    angle: Math.PI * 2,
     segments: outerSegments
   }
   return extrudeRotate(options, innerCircle)

--- a/src/primitives/torus.test.js
+++ b/src/primitives/torus.test.js
@@ -6,7 +6,7 @@ const {torus} = require('./index')
 
 const comparePolygonsAsPoints = require('../../test/helpers/comparePolygonsAsPoints')
 
-test.skip('torus (defaults)', t => {
+test('torus (defaults)', t => {
   const obs = torus()
   const pts = geom3.toPoints(obs)
   const exp = [
@@ -15,7 +15,7 @@ test.skip('torus (defaults)', t => {
   //t.true(comparePolygonsAsPoints(pts, exp))
 })
 
-test.skip('torus (custom inner circle, customer outer circle)', t => {
+test('torus (custom inner circle, customer outer circle)', t => {
   const obs = torus({innerRadius: 0.5, innerSegments: 4, outerRadius: 5, outerSegments: 8})
   const pts = geom3.toPoints(obs)
   const exp = [


### PR DESCRIPTION
These changes enable the torus primitive, which requires the extrudeRotate() function.

- [X] code changes complete
- [X] test coverage complete
- [X] review complete